### PR TITLE
Added|Changed: Fill `.ws_xpixel` and `.ws_ypixel` in `winsize`

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/JNI.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/JNI.java
@@ -23,10 +23,10 @@ final class JNI {
      * @return the file descriptor resulting from opening /dev/ptmx master device. The sub process will have opened the
      * slave device counterpart (/dev/pts/$N) and have it as stdint, stdout and stderr.
      */
-    public static native int createSubprocess(String cmd, String cwd, String[] args, String[] envVars, int[] processId, int rows, int columns);
+    public static native int createSubprocess(String cmd, String cwd, String[] args, String[] envVars, int[] processId, int rows, int columns, int cellWidth, int cellHeight);
 
     /** Set the window size for a given pty, which allows connected programs to learn how large their screen is. */
-    public static native void setPtyWindowSize(int fd, int rows, int cols);
+    public static native void setPtyWindowSize(int fd, int rows, int cols, int cellWidth, int cellHeight);
 
     /**
      * Causes the calling thread to wait for the process associated with the receiver to finish executing.

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -926,7 +926,7 @@ public final class TerminalView extends View {
         int newRows = Math.max(4, (viewHeight - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
 
         if (mEmulator == null || (newColumns != mEmulator.mColumns || newRows != mEmulator.mRows)) {
-            mTermSession.updateSize(newColumns, newRows);
+            mTermSession.updateSize(newColumns, newRows, (int) mRenderer.getFontWidth(), mRenderer.getFontLineSpacing());
             mEmulator = mTermSession.getEmulator();
             mClient.onEmulatorSet();
 


### PR DESCRIPTION
This allows to get terminal size in pixel using `TIOCGWINSZ` ioctl. Set `.ws_xpixel` using `columns * cell_width` and set `.ws_ypixel` using `rows * cell_height`. Cell width and height is font width and line spacing, respectively.